### PR TITLE
[gcp-idle-resources-metrics] Improve availability through rollingUpdate strategy

### DIFF
--- a/charts/gcp-idle-resources-metrics/Chart.yaml
+++ b/charts/gcp-idle-resources-metrics/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.1.0
+appVersion: v1.1.1
 
 maintainers:
   - name: 7onn

--- a/charts/gcp-idle-resources-metrics/README.md
+++ b/charts/gcp-idle-resources-metrics/README.md
@@ -1,8 +1,14 @@
 # gcp-idle-resources-metrics
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.1.0](https://img.shields.io/badge/AppVersion-v1.1.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
 
 A Helm chart for running gcp-idle-resources-metrics on Kubernetes
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| 7onn | devbytom@gmail.com |  |
 
 ## Values
 
@@ -25,7 +31,7 @@ A Helm chart for running gcp-idle-resources-metrics on Kubernetes
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
-| podDisruptionBudget | object | `{"annotations":{},"create":true,"minAvailable":1}` | Whether to create a PodDisruptionBudget resource |
+| podDisruptionBudget | object | `{"annotations":{},"create":false,"minAvailable":1}` | Whether to create a PodDisruptionBudget resource |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"100m"` |  |

--- a/charts/gcp-idle-resources-metrics/templates/deployment.yaml
+++ b/charts/gcp-idle-resources-metrics/templates/deployment.yaml
@@ -12,6 +12,11 @@ spec:
   selector:
     matchLabels:
       {{- include "gcp-idle-resources-metrics.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.replicaCount }}
+      maxUnavailable: 0
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
**Why is this pull request necessary, and what does it do**?
To avoid downtime during the workload rollout, this pull request configures a better rolling update strategy.

**Special notes for your reviewer**:
This complements this https://github.com/7onn/helm-charts/issues/1 since PodDisruptionBudget with a single replica application would harm draining actions on the cluster.

**Checklist**
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml
- [x] Chart README.md was updated by helm-docs
