### PR TITLE
Patch gcp-idleness-exporter

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.8.1
+          version: v3.16.3
       
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.10"
       
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
@@ -28,7 +28,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo 'changed="true"' >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Automatic Rebase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/charts/gcp-idleness-exporter/Chart.yaml
+++ b/charts/gcp-idleness-exporter/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2.0.2
+appVersion: v2.0.3
 
 maintainers:
   - name: 7onn


### PR DESCRIPTION
**Why is this pull request necessary, and what does it do**?
It brings a vulnerability patch: https://github.com/7onn/gcp-idleness-exporter/releases/tag/v2.0.3

**Special notes for your reviewer**:

**Checklist**
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the values.yaml
- [ ] Chart README.md was updated by helm-docs
